### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "dependencies": {
-    "binet": "~0.3.5",
-    "bns": "~0.10.0"
+    "binet": "~0.3.7",
+    "bns": "~0.15.0"
   },
   "devDependencies": {
-    "bmocha": "^2.1.3"
+    "bmocha": "^2.1.5"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
bns 0.10.0 uses bcrypto 5.0.0 which fails to build for me (darwin arm64 node 16)